### PR TITLE
chore(release): bump to 0.12.7 to ship the runtime-deps security fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "viz-js-lib",
-  "version": "0.12.4",
+  "version": "0.12.7",
   "description": "viz.js the JavaScript Library with API support for VIZ blockchain",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
## Why

The runtime-deps security fix from #5 — moving `babel-preset-env` and `cross-env` out of `dependencies` and into `devDependencies` — is merged on `master`, but it has **never reached npm**.

The latest published version is **0.12.6** (2026-05-17), which predates the #5 merge (2026-06-02). So every consumer installing from npm still pulls the EOL **babel-6 `babel-traverse`** chain (`GHSA-67hx-6x53-jw92`, arbitrary code execution, no patch available) into their production install — 23 critical advisories that originate entirely from this misplaced build-time dependency.

`master`'s `package.json` version field was stale at 0.12.4 (releases are version-bumped at publish time, not committed back).

## What this PR does

Bumps the version to **0.12.7** (greater than the published 0.12.6) so a maintainer with npm publish rights can cut a release that finally carries the fix. No code changes beyond the version field.

## Verification

Installing the current `master` tip from git installs **zero babel packages** and the module loads normally (`auth` + `api` present); the only residual advisory is `ws@^1.1.1`, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)